### PR TITLE
S-1006 点検予定一覧をサービス会社向けにレイアウト変更

### DIFF
--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -6,9 +6,9 @@ class InspectionSchedulesController < ApplicationController
   # GET /inspection_schedules
   # GET /inspection_schedules.json
   def index
-    # @inspection_schedules = InspectionSchedule.all
     @search = InspectionSchedule.search(params[:q])
     @inspection_schedules = @search.result.order(:targetyearmonth, :id).page(params[:page])
+    @my_schedules = InspectionSchedule.my_schedules(current_user)
   end
 
   # GET /inspection_schedules/1

--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -8,7 +8,7 @@ class InspectionSchedulesController < ApplicationController
   def index
     @search = InspectionSchedule.search(params[:q])
     @inspection_schedules = @search.result.order(:targetyearmonth, :id).page(params[:page])
-    @my_schedules = InspectionSchedule.my_schedules(current_user)
+    @my_schedules = InspectionSchedule.my_schedules(current_user.company)
   end
 
   # GET /inspection_schedules/1

--- a/app/models/inspection_schedule.rb
+++ b/app/models/inspection_schedule.rb
@@ -15,8 +15,8 @@ class InspectionSchedule < ActiveRecord::Base
   }
 
   scope :not_done, -> { includes(:status).where(status_id: Status.not_done_ids) }
-  scope :my_schedules, ->(user) {
-    includes(equipment: :place).where(user: user).not_done.includes(:equipment).order("equipment_id")
+  scope :my_schedules, ->(service) {
+    includes(equipment: :place).where(service: service).not_done.includes(:equipment).order("equipment_id")
   }
 
   # InspectionSchedule上に、1年前以前の情報しかないequipment_idの一覧を取得。

--- a/app/models/inspection_schedule.rb
+++ b/app/models/inspection_schedule.rb
@@ -14,6 +14,11 @@ class InspectionSchedule < ActiveRecord::Base
     group(:equipment_id).having("max(targetyearmonth) < '#{limit_date.strftime('%Y%m')}'")
   }
 
+  scope :not_done, -> { includes(:status).where(status_id: Status.not_done_ids) }
+  scope :my_schedules, ->(user) {
+    includes(equipment: :place).where(user: user).not_done.includes(:equipment).order("equipment_id")
+  }
+
   # InspectionSchedule上に、1年前以前の情報しかないequipment_idの一覧を取得。
   # TODO: 点検周期を過ぎた情報にする equipment_id にする必要があるはず。
   def self.old_inspection_equipment_list
@@ -82,5 +87,9 @@ class InspectionSchedule < ActiveRecord::Base
     else
       true # 完了してなければ良い（とりあえず）
     end
+  end
+
+  def place
+    equipment.place
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,4 +1,6 @@
 class Status < ActiveRecord::Base
+  scope :not_done, -> { where.not(id: Constants::Status::ID_DONE) }
+
   def self.of_unallocated
     Constants::Status::ID_UNALLOCATED
   end
@@ -13,5 +15,9 @@ class Status < ActiveRecord::Base
 
   def self.of_done
     Constants::Status::ID_DONE
+  end
+
+  def self.not_done_ids
+    not_done.ids
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,8 @@ class User < ActiveRecord::Base
       model.save!
     end
   end
+
+  def service_employee?
+    company.try(:type) == 'Service'
+  end
 end

--- a/app/views/inspection_schedules/_my_schedules_index.html.erb
+++ b/app/views/inspection_schedules/_my_schedules_index.html.erb
@@ -1,32 +1,4 @@
-<% breadcrumb :inspection_schedule_index %>
-<h1><%= t('views.inspection_schedule.index') %></h1>
-
-<% if @my_schedules.any? %>
-  <%= render 'my_schedules_index' %>
-<% end %>
-
-<h2><%= t('views.inspection_schedule.all_schedules') %></h2>
-<div class="well col-md-8 col-sm-8 col-xs-8">
-
- <%= search_form_for @search do |f| %>
-    <div>
-      <p>
-        <%= t('activerecord.attributes.inspection_schedule.service_id') %>
-        <%= f.collection_select(:service_id_eq, Service.all, :id, :name, :include_blank => true ) %>
-        <%= t('activerecord.attributes.inspection_schedule.status_id') %>
-        <%= f.collection_select(:status_id_eq, Status.all, :id, :name, :include_blank => true ) %>
-        <%= t('activerecord.attributes.equipment.place_id') %>
-        <%= f.collection_select(:equipment_place_id_eq, Place.all, :id, :name, :include_blank => true ) %>
-      </p>
-    </div>
-    <div>
-      <%= f.submit t('helpers.submit.search') %>
-    </div>
-  <% end %>
-
-
-</div>
-
+<h2><%= t('views.inspection_schedule.my_schedules') %></h2>
 <table>
   <thead>
     <tr>
@@ -34,7 +6,6 @@
       <th><%= t('activerecord.attributes.inspection_schedule.equipment_id') %></th>
       <th><%= t('activerecord.attributes.equipment.place_id') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.status_id') %></th>
-      <th><%= t('activerecord.attributes.inspection_schedule.service_id') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.result_id') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.processingdate') %></th>
       <th colspan="4"></th>
@@ -42,13 +13,12 @@
   </thead>
 
   <tbody>
-    <% @inspection_schedules.each do |inspection_schedule| %>
+    <% @my_schedules.each do |inspection_schedule| %>
       <tr>
         <td><%= inspection_schedule.targetyearmonth %></td>
         <td><%= inspection_schedule.equipment.name %></td>
         <td><%= inspection_schedule.place.name %></td>
         <td><%= inspection_schedule.status.name %></td>
-        <td><%= inspection_schedule.service.name %></td>
         <td><%= inspection_schedule.result.name %></td>
         <td><%= inspection_schedule.processingdate %></td>
         <td>
@@ -84,8 +54,3 @@
     <% end %>
   </tbody>
 </table>
-
-<%= paginate(@inspection_schedules) %>
-<br>
-
-<%= link_to t('views.link_to.new'), new_inspection_schedule_path %>

--- a/app/views/inspection_schedules/_my_schedules_index.html.erb
+++ b/app/views/inspection_schedules/_my_schedules_index.html.erb
@@ -1,56 +1,62 @@
-<h2><%= t('views.inspection_schedule.my_schedules') %></h2>
-<table>
-  <thead>
-    <tr>
-      <th><%= t('activerecord.attributes.inspection_schedule.targetyearmonth') %></th>
-      <th><%= t('activerecord.attributes.inspection_schedule.equipment_id') %></th>
-      <th><%= t('activerecord.attributes.equipment.place_id') %></th>
-      <th><%= t('activerecord.attributes.inspection_schedule.status_id') %></th>
-      <th><%= t('activerecord.attributes.inspection_schedule.result_id') %></th>
-      <th><%= t('activerecord.attributes.inspection_schedule.processingdate') %></th>
-      <th colspan="4"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @my_schedules.each do |inspection_schedule| %>
+<h2><%= t('views.inspection_schedule.my_schedules', company_name: current_user.company.name) %></h2>
+<% @my_schedules.group_by { |s| s.equipment.place }.each do |schedules_group_by_place| %>
+  <% place, schedules = schedules_group_by_place.first, schedules_group_by_place.second %>
+  <h3><%= place.name %></h3>
+  <%= link_to t('views.inspection_schedule.index_by_place', place_name: place.name),
+    "#{inspection_schedules_path}/?q[equipment_place_id_eq]=#{place.id}\#all" %>
+  <table>
+    <thead>
       <tr>
-        <td><%= inspection_schedule.targetyearmonth %></td>
-        <td><%= inspection_schedule.equipment.name %></td>
-        <td><%= inspection_schedule.place.name %></td>
-        <td><%= inspection_schedule.status.name %></td>
-        <td><%= inspection_schedule.result.name %></td>
-        <td><%= inspection_schedule.processingdate %></td>
-        <td>
-          <% if inspection_schedule.can_inspection? %>
-            <%= link_to  do_inspection_path(inspection_schedule) do %>
-              <i class="fa fa-pencil fa-fw"></i>
-              <%= t('views.inspection_schedule.do_inspecrion') %>
-            <% end %>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to inspection_schedule do %>
-            <i class="fa fa-newspaper-o fa-fw"></i>
-            <%= t('views.link_to.show') %>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to_if(inspection_schedule.doing?, t('views.inspection_schedule.done_inspection'), done_inspection_path(inspection_schedule) ){} %>
-        </td>
-        <td>
-          <%= link_to edit_inspection_schedule_path(inspection_schedule) do %>
-            <i class="fa fa-refresh fa-fw"></i>
-            <%=  t('views.link_to.edit') %>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to inspection_schedule, method: :delete, data: { confirm: 'Are you sure?' } do %>
-            <i class="fa fa-trash-o fa-fw"></i>
-            <%= t('views.link_to.destroy') %>
-          <% end %>
-        </td>
+        <th><%= t('activerecord.attributes.inspection_schedule.targetyearmonth') %></th>
+        <th><%= t('activerecord.attributes.inspection_schedule.equipment_id') %></th>
+        <th><%= t('activerecord.attributes.equipment.place_id') %></th>
+        <th><%= t('activerecord.attributes.inspection_schedule.status_id') %></th>
+        <th><%= t('activerecord.attributes.inspection_schedule.result_id') %></th>
+        <th><%= t('activerecord.attributes.inspection_schedule.processingdate') %></th>
+        <th colspan="4"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+      <% schedules.each do |inspection_schedule| %>
+        <tr>
+          <td><%= inspection_schedule.targetyearmonth %></td>
+          <td><%= inspection_schedule.equipment.name %></td>
+          <td><%= inspection_schedule.place.name %></td>
+          <td><%= inspection_schedule.status.name %></td>
+          <td><%= inspection_schedule.result.name %></td>
+          <td><%= inspection_schedule.processingdate %></td>
+          <td>
+            <% if inspection_schedule.can_inspection? %>
+              <%= link_to  do_inspection_path(inspection_schedule) do %>
+                <i class="fa fa-pencil fa-fw"></i>
+                <%= t('views.inspection_schedule.do_inspecrion') %>
+              <% end %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to inspection_schedule do %>
+              <i class="fa fa-newspaper-o fa-fw"></i>
+              <%= t('views.link_to.show') %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to_if(inspection_schedule.doing?, t('views.inspection_schedule.done_inspection'), done_inspection_path(inspection_schedule) ){} %>
+          </td>
+          <td>
+            <%= link_to edit_inspection_schedule_path(inspection_schedule) do %>
+              <i class="fa fa-refresh fa-fw"></i>
+              <%=  t('views.link_to.edit') %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to inspection_schedule, method: :delete, data: { confirm: 'Are you sure?' } do %>
+              <i class="fa fa-trash-o fa-fw"></i>
+              <%= t('views.link_to.destroy') %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/inspection_schedules/index.html.erb
+++ b/app/views/inspection_schedules/index.html.erb
@@ -1,7 +1,7 @@
 <% breadcrumb :inspection_schedule_index %>
 <h1><%= t('views.inspection_schedule.index') %></h1>
 
-<% if @my_schedules.any? %>
+<% if current_user.service_employee? && @my_schedules.any? %>
   <%= render 'my_schedules_index' %>
 <% end %>
 

--- a/app/views/inspection_schedules/index.html.erb
+++ b/app/views/inspection_schedules/index.html.erb
@@ -1,17 +1,19 @@
 <% breadcrumb :inspection_schedule_index %>
 <h1><%= t('views.inspection_schedule.index') %></h1>
 
-<div class="well col-md-4 col-sm-4 col-xs-4">
+<div class="well col-md-8 col-sm-8 col-xs-8">
 
  <%= search_form_for @search do |f| %>
     <div>
-    <p>
-    <%= t('activerecord.attributes.inspection_schedule.service_id') %>
-    <%= f.collection_select(:service_id_eq, Service.all, :id, :name, :include_blank => true ) %>
-    <%= t('activerecord.attributes.inspection_schedule.status_id') %>
-    <%= f.collection_select(:status_id_eq, Status.all, :id, :name, :include_blank => true ) %>
+      <p>
+        <%= t('activerecord.attributes.inspection_schedule.service_id') %>
+        <%= f.collection_select(:service_id_eq, Service.all, :id, :name, :include_blank => true ) %>
+        <%= t('activerecord.attributes.inspection_schedule.status_id') %>
+        <%= f.collection_select(:status_id_eq, Status.all, :id, :name, :include_blank => true ) %>
+        <%= t('activerecord.attributes.equipment.place_id') %>
+        <%= f.collection_select(:equipment_place_id_eq, Place.all, :id, :name, :include_blank => true ) %>
+      </p>
     </div>
-    </p>
     <div>
       <%= f.submit t('helpers.submit.search') %>
     </div>
@@ -25,6 +27,7 @@
     <tr>
       <th><%= t('activerecord.attributes.inspection_schedule.targetyearmonth') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.equipment_id') %></th>
+      <th><%= t('activerecord.attributes.equipment.place_id') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.status_id') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.service_id') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.result_id') %></th>
@@ -38,6 +41,7 @@
       <tr>
         <td><%= inspection_schedule.targetyearmonth %></td>
         <td><%= inspection_schedule.equipment.name %></td>
+        <td><%= inspection_schedule.place.name %></td>
         <td><%= inspection_schedule.status.name %></td>
         <td><%= inspection_schedule.service.name %></td>
         <td><%= inspection_schedule.result.name %></td>

--- a/app/views/inspection_schedules/index.html.erb
+++ b/app/views/inspection_schedules/index.html.erb
@@ -5,7 +5,7 @@
   <%= render 'my_schedules_index' %>
 <% end %>
 
-<h2><%= t('views.inspection_schedule.all_schedules') %></h2>
+<h2 id="all"><%= t('views.inspection_schedule.all_schedules') %></h2>
 <div class="well col-md-8 col-sm-8 col-xs-8">
 
  <%= search_form_for @search do |f| %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -29,7 +29,8 @@ ja:
       do_inspecrion: 点検開始
       done_inspection: 点検の完了
       close_inspecrion: 点検完了(承認)
-      my_schedules: 担当中の点検予定一覧
+      my_schedules: "%{company_name}の点検予定一覧"
+      index_by_place: "%{place_name}の点検予定を全て見る"
       all_schedules: 全ての点検予定一覧
     inspection_request:
       index: 点検依頼一覧

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -29,6 +29,8 @@ ja:
       do_inspecrion: 点検開始
       done_inspection: 点検の完了
       close_inspecrion: 点検完了(承認)
+      my_schedules: 担当中の点検予定一覧
+      all_schedules: 全ての点検予定一覧
     inspection_request:
       index: 点検依頼一覧
       new: 点検依頼の登録


### PR DESCRIPTION
サービス会社のユーザー(作業員)が、自分の点検予定一覧を素早く確認できるようにし、
自分の点検予定の設置場所と同じものを素早く検索できるようにして下記を実現する。

> (サービス会社として)工事予定の装置のお客様先に設置されているすべての装置を(他サービス会社の担当のものも含めて)確認したい。同一のお客様先にある装置については(他サービス会社の担当のものも含めて)まとめて点検する方が効率が良いから。
