### PR TITLE
S-01013 顧客のサインが登録できるようにする

### DIFF
--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -1,6 +1,6 @@
 class InspectionSchedulesController < ApplicationController
   before_action :set_inspection_schedule, only: [
-    :show, :edit, :update, :destroy, :do_inspection, :done_inspection, :close_inspection
+    :show, :edit, :update, :destroy, :do_inspection, :done_inspection, :approve_inspection
   ]
 
   # GET /inspection_schedules
@@ -98,12 +98,12 @@ class InspectionSchedulesController < ApplicationController
     redirect_to root_path, notice: t('controllers.inspection_schedules.make_branch_yyyymm')
   end
 
-  # 点検完了の登録
-  def close_inspection
+  # 承認の登録
+  def approve_inspection
     @approval = @inspection_schedule.result.build_approval
     @approval.signature = params[:sign]
 
-    @inspection_schedule.close_inspection
+    @inspection_schedule.approve_inspection
 
     respond_to do |format|
       if @inspection_schedule.save && @approval.save

--- a/app/models/inspection_schedule.rb
+++ b/app/models/inspection_schedule.rb
@@ -76,6 +76,12 @@ class InspectionSchedule < ActiveRecord::Base
     self.processingdate = current_date
   end
 
+  # 顧客承認済みに変更
+  def approve_inspection
+    self.schedule_status_id = ScheduleStatus.of_approved
+    self.processingdate = current_date
+  end
+
   # 完了に変更
   def close_inspection
     self.schedule_status_id = ScheduleStatus.of_completed

--- a/app/views/inspection_results/_show.html.erb
+++ b/app/views/inspection_results/_show.html.erb
@@ -4,6 +4,17 @@
 </p>
 
 <p>
+  <strong><%= t('activerecord.attributes.approval.signature') %>:</strong>
+  <% if inspection_result.approval.present? %>
+    <%= raw inspection_result.approval.signature %>
+  <% else %>
+    <%= t('views.approval.signature_not_yet') %>
+  <% end %>
+</p>
+
+<hr>
+
+<p>
   <strong><%= t('activerecord.attributes.inspection_result.latitude') %>:</strong>
   <%= inspection_result.latitude %>
 </p>

--- a/app/views/inspection_schedules/_index_by_place.html.erb
+++ b/app/views/inspection_schedules/_index_by_place.html.erb
@@ -19,7 +19,7 @@
         <td><%= inspection_schedule.equipment.name %></td>
         <td><%= inspection_schedule.place.name %></td>
         <td><%= inspection_schedule.service.name %></td>
-        <td><%= inspection_schedule.result_name %></td>
+        <td><%= inspection_schedule.schedule_status.name %></td>
         <td><%= inspection_schedule.processingdate %></td>
         <td>
           <% if inspection_schedule.can_inspection? %>

--- a/app/views/inspection_schedules/done_inspection.html.erb
+++ b/app/views/inspection_schedules/done_inspection.html.erb
@@ -48,7 +48,7 @@
 <hr>
 
 <%= t('activerecord.attributes.approval.signature') %><br />
-<%= form_tag action='close_inspection' do %>
+<%= form_tag action='approve_inspection' do %>
   <div>
     <script type="text/javascript" src="./libs/fabric.js"></script>
     <canvas id="canvas" width="300" height="300" style="border:1px solid;">ご利用のブラウザでは署名欄は表示できません。</canvas>

--- a/config/locales/attributes.ja.yml
+++ b/config/locales/attributes.ja.yml
@@ -76,4 +76,4 @@ ja:
         created_at: 登録日
         updated_at: 最終更新日
       approval:
-        signature: 署名
+        signature: お客様署名(承認)

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -30,9 +30,9 @@ ja:
       new: 点検予定の登録
       edit: 点検予定の更新
       show: 点検予定の確認
-      do_inspecrion: 点検開始
-      done_inspection: 点検の完了
-      close_inspecrion: 点検完了(承認)
+      do_inspecrion: 点検実施
+      done_inspection: 承認(作業終了)
+      close_inspecrion: 点検完了
       my_schedules: "%{company_name}の点検予定一覧"
       schedules_by_place: "%{place_name}の点検予定一覧"
     equipment:
@@ -64,6 +64,9 @@ ja:
     note:
       note: その他点検実績
       show: その他点検実績の確認
+    approval:
+      signature_not_yet: 未(承認前)
+
     company:
       index: 会社の一覧
       new: 会社の登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   get 'inspection_schedules/:id/done_inspection' => 'inspection_schedules#done_inspection' , as: 'done_inspection'
 
   # 点検を完了(StatusをDoneに）する
-  post 'inspection_schedules/:id/close_inspection' => 'inspection_schedules#close_inspection'
+  post 'inspection_schedules/:id/approve_inspection' => 'inspection_schedules#approve_inspection'
 
   resources :equipment do
     collection { post :import }  # for CSV Upload


### PR DESCRIPTION
kilogyとの違いの調整
・名称変更：close_inspection → approve_inspection
　※Status を完了(COMPLETED)にする為のメソッドを close_inspection にしたいと思っています。
　　ので、kilogyの時にあった close_～ は approve_～ に変更して歩きました。
・↑に伴っての locales/～.ja.yml 系の変更
・点検予定の一覧関係で進捗く状況(ScheduleStatus)が表示されてないところがあったので併せて修正
