### PR TITLE
S 01019(その１)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def date_value(date)
+    date.strftime("%Y年%m月%d日") if date.present?
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,2 @@
 module ApplicationHelper
-  def date_value(date)
-    date.strftime("%Y年%m月%d日") if date.present?
-  end
 end

--- a/app/helpers/equipment_helper.rb
+++ b/app/helpers/equipment_helper.rb
@@ -25,4 +25,12 @@ module EquipmentHelper
   def selected_branch_id
     @equipment.new_record? ? current_user.branch.id : @equipment.branch_id
   end
+
+  def inspection_contract_string
+    if @equipment.inspection_contract then
+      t('views.equipment.inspection_contract_true')
+    else
+      t('views.equipment.inspection_contract_false')
+    end
+  end
 end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -10,7 +10,7 @@ class Equipment < ActiveRecord::Base
 
   validates :serial_number, presence: true, uniqueness: { scope: :system_model }
   validates :serial_number, :format => { :with => /\A[A-Z0-9-]+\z/, :message => "は半角英数字とハイフンのみで記入して下さい" }
-  after_create :create_inspection_schedule
+  after_create :create_inspection_schedule, :if => :inspection_contract
 
   # CSV Upload
   require "csv"
@@ -79,6 +79,6 @@ class Equipment < ActiveRecord::Base
   private
 
   def first_inspection_cycle
-    Date.parse(current_date) >> system_model.inspection_cycle_month
+    Date.parse(start_date.to_s[0..9]) >> inspection_cycle_month
   end
 end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -32,45 +32,6 @@ class Equipment < ActiveRecord::Base
     )
   end
 
-  # 渡された年月が自分の点検年月にあたるかを Yes/No で回答する
-  def is_inspection_datetime(target_year, target_month)
-
-    res = true # 戻り値を設定。点検予定が１つも無いときは true で抜けるよ。
-
-    # 点検予定の最未来のものを取る(１件だけ)
-    inspection_schedules = self.inspection_schedules.order(target_yearmonth: :desc).limit(1)
-
-    inspection_schedules.each do | last_inspection_schedule |
-      # 最未来の点検予定の年月を年と月に分割
-      last_ym = last_inspection_schedule.target_yearmonth.scan(/.{1,#{4}}/)
-
-      # 型式の点検周期(月)を年と月に分割
-      inc_year  = self.system_model.inspection_cycle_month/12
-      inc_month = self.system_model.inspection_cycle_month%12
-
-      # 最未来の点検予定から起算した次回の点検年と月を計算
-      next_y = last_ym[0].to_i+inc_year
-      next_m = last_ym[1].to_i+inc_month
-
-      if target_year.to_i==next_y and target_month.to_i==next_m
-        res = true # 一致の時
-      else
-        res = false
-      end
-    end
-
-    return res
-  end
-
-  # 渡された年月の点検予定が存在するかを Yes/No で回答する
-  def exist_inspection(target_year, target_month)
-    if InspectionSchedule.where(equipment_id: self.id, target_yearmonth: target_year+target_month).count == 0
-      return false # ない
-    else
-      return true # ある
-    end
-  end
-
   # 次回の点検予定
   def next_inspection_schedule
     inspection_schedules.not_done.order_by_target_yearmonth.first

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -8,6 +8,8 @@ class Equipment < ActiveRecord::Base
 
   has_many :inspection_schedules
 
+  validates :serial_number, presence: true, uniqueness: { scope: :system_model }
+  validates :serial_number, :format => { :with => /\A[A-Z0-9-]+\z/, :message => "は半角英数字とハイフンのみで記入して下さい" }
   after_create :create_inspection_schedule
 
   # CSV Upload

--- a/app/models/inspection_schedule.rb
+++ b/app/models/inspection_schedule.rb
@@ -28,27 +28,6 @@ class InspectionSchedule < ActiveRecord::Base
                       .pluck(:equipment_id)
   end
 
-  # 拠点が管轄する装置システムの点検予定を作成する
-  #   target_brahch_id 点検予定を作成する対象の拠点
-  #   target_year      点検予定作成対象の年
-  #   target_month     点検予定作成対象の月
-  def self.make_branch_yyyym(target_brahch_id, target_year, target_month, current_date)
-    equipments = Equipment.where(branch_id: target_brahch_id)
-    equipments.each do |equipment|
-      if equipment.is_inspection_datetime(target_year, target_month) && # 該当装置システムの点検年月にあたる
-         !equipment.exist_inspection(target_year, target_month)          # 該当年月の点検スケジュールが未だ無い
-        new_inspection_schedule = new(
-          target_yearmonth: target_year+target_month,
-          equipment_id: equipment.id,
-          service_id: equipment.service_id,
-          schedule_status_id: ScheduleStatus.of_requested,
-          processingdate: current_date
-        )
-        new_inspection_schedule.save
-      end
-    end
-  end
-
   ###
   # ステータス変更シリーズ
   # TODO: 後で全ケース作る

--- a/app/views/equipment/_form.html.erb
+++ b/app/views/equipment/_form.html.erb
@@ -12,12 +12,24 @@
   <% end %>
 
   <div class="field">
+    <%= f.label :system_model_id %><br>
+    <%= f.collection_select(:system_model_id, SystemModel.all, :id, :name) %>
+  </div>
+  <div class="field">
     <%= f.label :serial_number %><br>
     <%= f.text_field :serial_number %>
   </div>
   <div class="field">
-    <%= f.label :system_model_id %><br>
-    <%= f.collection_select(:system_model_id, SystemModel.all, :id, :name) %>
+    <%= f.label :inspection_contract %>
+    <%= f.check_box :inspection_contract, {:checked => true} %>
+  </div>
+  <div class="field">
+    <%= f.label :inspection_cycle_month %><br>
+    <%= f.number_field :inspection_cycle_month %>
+  </div>
+  <div class="field">
+    <%= f.label :start_date %><br>
+    <%= f.date_select :start_date, {} %>
   </div>
   <div class="field">
     <%= f.label :place_id %><br>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -4,13 +4,28 @@
 <p id="notice"><%= notice %></p>
 
 <p>
+  <strong><%= t('activerecord.attributes.equipment.system_model_id') %>:</strong>
+  <%= @equipment.system_model.name %>
+</p>
+
+<p>
   <strong><%= t('activerecord.attributes.equipment.serial_number') %>:</strong>
   <%= @equipment.serial_number %>
 </p>
 
 <p>
-  <strong><%= t('activerecord.attributes.equipment.system_model_id') %>:</strong>
-  <%= @equipment.system_model.name %>
+  <strong><%= t('activerecord.attributes.equipment.inspection_cycle_month') %>:</strong>
+  <%= @equipment.inspection_cycle_month %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
+  <%= if @equipment.inspection_contract then t('views.equipment.inspection_contract_true') else t('views.equipment.inspection_contract_true') end %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.equipment.start_date') %>:</strong>
+  <%= date_value(@equipment.start_date) %>
 </p>
 
 <p>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -14,13 +14,13 @@
 </p>
 
 <p>
-  <strong><%= t('activerecord.attributes.equipment.inspection_cycle_month') %>:</strong>
-  <%= @equipment.inspection_cycle_month %>
+  <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
+  <%= if @equipment.inspection_contract then t('views.equipment.inspection_contract_true') else t('views.equipment.inspection_contract_true') end %>
 </p>
 
 <p>
-  <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
-  <%= if @equipment.inspection_contract then t('views.equipment.inspection_contract_true') else t('views.equipment.inspection_contract_true') end %>
+  <strong><%= t('activerecord.attributes.equipment.inspection_cycle_month') %>:</strong>
+  <%= @equipment.inspection_cycle_month %>
 </p>
 
 <p>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -15,7 +15,7 @@
 
 <p>
   <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
-  <%= if @equipment.inspection_contract then t('views.equipment.inspection_contract_true') else t('views.equipment.inspection_contract_true') end %>
+  <%= if @equipment.inspection_contract then t('views.equipment.inspection_contract_true') else t('views.equipment.inspection_contract_false') end %>
 </p>
 
 <p>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -15,7 +15,7 @@
 
 <p>
   <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
-  <%= if @equipment.inspection_contract then t('views.equipment.inspection_contract_true') else t('views.equipment.inspection_contract_false') end %>
+  <%= inspection_contract_string %>
 </p>
 
 <p>

--- a/app/views/inspection_schedules/_form.html.erb
+++ b/app/views/inspection_schedules/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= f.label :equipment_id %><br>
-    <%= f.collection_select(:equipment_id, Equipment.all, :id, :name) %>
+    <%= f.collection_select(:equipment_id, Equipment.all, :id, :serial_number) %>
   </div>
 
   <div class="field">

--- a/config/locales/attributes.ja.yml
+++ b/config/locales/attributes.ja.yml
@@ -50,6 +50,9 @@ ja:
         company_id: 所属
       equipment:
         serial_number: シリアルNo.
+        inspection_cycle_month: 点検周期
+        inspection_contract: 点検契約
+        start_date: 試運転日
         system_model_id: 型式
         place_id: 設置場所
         branch_id: 管轄

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -45,6 +45,8 @@ ja:
       new: 装置システムの登録
       edit: 装置システムの更新
       show: 装置システムの確認
+      inspection_contract_true: 有
+      inspection_contract_false: 無
     system_model:
       index: 型式一覧
       new: 型式の登録


### PR DESCRIPTION
とりあえず最低限必要な以下を作りました。併せて不要なコード(Sprint1で拠点に対する点検予定を生成するために作ったコード)を削除。

・装置システムのシリアルＮｏについて
　- 英大文字、数字、およびハイフンのみ入力可、文字数の制限はとくになし
　- 型式＋シリアルＮｏで一意になるようにする(同一のものが既にあればエラー)

・装置システムの登録時に以下を指示できる
- 試運転日
- 点検契約の有無
- 点検周期

・初回の点検予定の生成について
　- 点検契約有の時のみ点検予定が作成される
  　※点検契約無の場合は点検予定は作成されない(装置システムが登録されるだけ) 
　- 試運転日を起算日として設定された点検周期後の年月で作成される

できてないこと
　・画面上で点検周期のデフォルトが型式の点検周期になる
　・点検周期は点検契約有の時だけ入力可になる
