### PR TITLE
S-01021同一設置場所の装置システムの点検周期を一括変更する

### DIFF
--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -92,6 +92,7 @@ class EquipmentController < ApplicationController
 
   end
 
+  # 点検周期を一括で変更する
   def change_inspection_cycle
     params[:check].each do |key, val|
       if val=="1"
@@ -100,7 +101,7 @@ class EquipmentController < ApplicationController
         equipment.save
       end
     end
-     redirect_to equipment_index_url
+    redirect_to placed_equipment_path(params[:place_id])
   end
 
   private

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -94,13 +94,7 @@ class EquipmentController < ApplicationController
 
   # 点検周期を一括で変更する
   def change_inspection_cycle
-    params[:check].each do |key, val|
-      if val=="1"
-        equipment = Equipment.where(id: key).first
-        equipment.inspection_cycle_month = params[:new_inspection_cycle_month]
-        equipment.save
-      end
-    end
+    Equipment.bulk_change_inspection_cycle(params[:check], params[:new_inspection_cycle_month])
     redirect_to placed_equipment_path(params[:place_id])
   end
 

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -87,7 +87,20 @@ class EquipmentController < ApplicationController
   end
 
   def placed_equipment
-    @equipment = Equipment.where(place_id: params[:place_id])
+    @place = Place.where(id: params[:place_id]).first
+    @equipment = Equipment.where(place: @place)
+
+  end
+
+  def change_inspection_cycle
+    params[:check].each do |key, val|
+      if val=="1"
+        equipment = Equipment.where(id: key).first
+        equipment.inspection_cycle_month = params[:new_inspection_cycle_month]
+        equipment.save
+      end
+    end
+     redirect_to equipment_index_url
   end
 
   private

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -6,7 +6,18 @@ class EquipmentController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        @equipment = Equipment.all
+        # YES本社：全件
+        if current_user.head_employee?
+          @equipment = Equipment.all
+        end
+        # YES拠点：自拠点が管轄しているもののみ
+        if current_user.branch_employee?
+           @equipment = Equipment.where(branch_id: current_user.company_id)
+        end
+        # サービス会社の場合：デフォルトの担当として割り当てられているもののみ
+        if current_user.service_employee?
+           @equipment = Equipment.where(service_id: current_user.company_id)
+        end
       end
       format.csv do
         @equipment = Equipment.all
@@ -73,6 +84,10 @@ class EquipmentController < ApplicationController
   def import
     Equipment.import(params[:file])
     redirect_to equipment_index_url, notice: "Equipment imported."
+  end
+
+  def placed_equipment
+    @equipment = Equipment.where(place_id: params[:place_id])
   end
 
   private

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -6,7 +6,15 @@ class PlacesController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        @places = Place.all
+        # YES本社：全件
+        if current_user.head_employee?
+          @places = Place.all
+        end
+        # YES拠点：自拠点が管轄しているもののみ
+        if current_user.branch_employee?
+          @places= Place.where(branch_id: current_user.company_id)
+        end
+        # サービス会社：なし
       end
       format.csv do
         @places = Place.all

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -37,6 +37,16 @@ class Equipment < ActiveRecord::Base
     InspectionSchedule.where(equipment: self, schedule_status_id: ScheduleStatus.of_need_request).delete_all
   end
 
+  def self.bulk_change_inspection_cycle(target_list, new_inspection_cycle_month)
+    target_list.each do |key, val|
+      if val=="1"
+        equipment = Equipment.where(id: key).first
+        equipment.inspection_cycle_month = new_inspection_cycle_month
+        equipment.save
+      end
+    end
+  end
+
   # 次回の点検予定
   def next_inspection_schedule
     inspection_schedules.not_done.order_by_target_yearmonth.first

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -1,13 +1,14 @@
 
-<h1><%= t('views.equipment.xxxxx') %></h1>
+<h1><%= t('views.equipment.placed_equipment', place_name: @place.name) %></h1>
 
+<%= form_tag action='change_inspection_cycle' do %>
 <table>
   <thead>
     <tr>
-      <th><%= t('activerecord.attributes.equipment.serial_number') %></th>
+      <th></th>
       <th><%= t('activerecord.attributes.equipment.system_model_id') %></th>
-      <th><%= t('activerecord.attributes.equipment.place_id') %></th>
-      <th><%= t('activerecord.attributes.equipment.branch_id') %></th>
+      <th><%= t('activerecord.attributes.equipment.serial_number') %></th>
+      <th><%= t('activerecord.attributes.equipment.inspection_cycle_month') %></th>
       <th><%= t('activerecord.attributes.equipment.service_id') %></th>
       <th><%= t('activerecord.attributes.equipment.last_update') %></th>
       <th colspan="5"></th>
@@ -17,10 +18,10 @@
   <tbody>
     <% @equipment.each do |equipment| %>
       <tr>
-        <td><%= equipment.serial_number %></td>
+        <td><%= check_box 'check', equipment.id, :id => "equipment_#{equipment.id}" %></td>
         <td><%= equipment.system_model.name %></td>
-        <td><%= equipment.place.name %></td>
-        <td><%= equipment.branch.name %></td>
+        <td><%= equipment.serial_number %></td>
+        <td><%= equipment.inspection_cycle_month %></td>
         <td><%= equipment.service.name %></td>
         <td><%= equipment.updated_at %></td>
         <td><%= link_to t('views.link_to.show'), equipment %></td>
@@ -33,17 +34,15 @@
 
 <br>
 
-<%= link_to link_to t('views.link_to.new'), new_equipment_path %>
+<% unless @equipment.empty? %>
+  <div class="well col-md-10 col-sm-10 col-xs-10">
+    <div><%= t('views.equipment.change_inspection_cycle_comment') %></div>
+    <div>
+      <%= number_field_tag :new_inspection_cycle_month %>
+      <%= submit_tag(t('views.equipment.change_inspection_cycle')) %>
+    </div>
+  </div>
+<% end %>
 
-<br><hr><br>
 
-<p>
-  <%= link_to t('views.link_to.csv_download'), equipment_index_path(format: :csv) %>
-</p>
-
-<p>
-  <%= form_tag import_equipment_index_path, multipart: true do %>
-    <%= file_field_tag :file %>
-    <%= submit_tag t('views.link_to.csv_upload') %>
-  <% end %>
-</p>
+<% end %>

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -38,6 +38,7 @@
   <div class="well col-md-10 col-sm-10 col-xs-10">
     <div><%= t('views.equipment.change_inspection_cycle_comment') %></div>
     <div>
+      <%= hidden_field_tag :place_id, :place_id, :value => @place.id %>
       <%= number_field_tag :new_inspection_cycle_month %>
       <%= submit_tag(t('views.equipment.change_inspection_cycle')) %>
     </div>

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -1,0 +1,49 @@
+
+<h1><%= t('views.equipment.xxxxx') %></h1>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= t('activerecord.attributes.equipment.serial_number') %></th>
+      <th><%= t('activerecord.attributes.equipment.system_model_id') %></th>
+      <th><%= t('activerecord.attributes.equipment.place_id') %></th>
+      <th><%= t('activerecord.attributes.equipment.branch_id') %></th>
+      <th><%= t('activerecord.attributes.equipment.service_id') %></th>
+      <th><%= t('activerecord.attributes.equipment.last_update') %></th>
+      <th colspan="5"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @equipment.each do |equipment| %>
+      <tr>
+        <td><%= equipment.serial_number %></td>
+        <td><%= equipment.system_model.name %></td>
+        <td><%= equipment.place.name %></td>
+        <td><%= equipment.branch.name %></td>
+        <td><%= equipment.service.name %></td>
+        <td><%= equipment.updated_at %></td>
+        <td><%= link_to t('views.link_to.show'), equipment %></td>
+        <td><%= link_to t('views.link_to.edit'), edit_equipment_path(equipment) %></td>
+        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to link_to t('views.link_to.new'), new_equipment_path %>
+
+<br><hr><br>
+
+<p>
+  <%= link_to t('views.link_to.csv_download'), equipment_index_path(format: :csv) %>
+</p>
+
+<p>
+  <%= form_tag import_equipment_index_path, multipart: true do %>
+    <%= file_field_tag :file %>
+    <%= submit_tag t('views.link_to.csv_upload') %>
+  <% end %>
+</p>

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -7,8 +7,7 @@
       <th>Name</th>
       <th>Address</th>
       <th>Branch</th>
-      <th>placed_equipment</th>
-      <th colspan="3"></th>
+      <th colspan="4"></th>
     </tr>
   </thead>
 
@@ -18,7 +17,7 @@
         <td><%= place.name %></td>
         <td><%= place.address %></td>
         <td><%= place.branch.try(:name) %></td>
-        <td><%= link_to 'placed_equipment', placed_equipment_path(place) %></td>
+        <td><%= link_to  t('views.place.placed_equipment'), placed_equipment_path(place) %></td>
         <td><%= link_to 'Show', place %></td>
         <td><%= link_to 'Edit', edit_place_path(place) %></td>
         <td><%= link_to 'Destroy', place, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -7,6 +7,7 @@
       <th>Name</th>
       <th>Address</th>
       <th>Branch</th>
+      <th>placed_equipment</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -17,6 +18,7 @@
         <td><%= place.name %></td>
         <td><%= place.address %></td>
         <td><%= place.branch.try(:name) %></td>
+        <td><%= link_to 'placed_equipment', placed_equipment_path(place) %></td>
         <td><%= link_to 'Show', place %></td>
         <td><%= link_to 'Edit', edit_place_path(place) %></td>
         <td><%= link_to 'Destroy', place, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -1,5 +1,5 @@
 <% breadcrumb :place_show %>
-<h1><%= t('views.equipment.show') %></h1>
+<h1><%= t('views.place.show') %></h1>
 <p id="notice"><%= notice %></p>
 
 <p>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -49,6 +49,9 @@ ja:
       show: 装置システムの確認
       inspection_contract_true: 有
       inspection_contract_false: 無
+      placed_equipment: "%{place_name}の装置システム一覧"
+      change_inspection_cycle_comment: 上記一覧で選択(チェック)した設備の点検周期を一括変更します
+      change_inspection_cycle: 点検周期変更
     system_model:
       index: 型式一覧
       new: 型式の登録
@@ -59,6 +62,7 @@ ja:
       new: 場所の登録
       edit: 場所の更新
       show: 場所の確認
+      placed_equipment: 装置システム一覧
     inspection_result:
       index: 点検実績一覧
       new: 点検実績の登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,9 @@ Rails.application.routes.draw do
   get 'inspection_schedules/:id/close_inspection' => 'inspection_schedules#close_inspection', as: 'close_inspection'
   post 'inspection_schedules/:id/complete_inspection' => 'inspection_schedules#complete_inspection'
 
+  # 装置システムの点検周期を一括返還する
+  get 'equipment/placed_equipment/:place_id' => 'equipment#placed_equipment', as: 'placed_equipment'
+
   resources :equipment do
     collection { post :import }  # for CSV Upload
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,8 +59,9 @@ Rails.application.routes.draw do
   get 'inspection_schedules/:id/close_inspection' => 'inspection_schedules#close_inspection', as: 'close_inspection'
   post 'inspection_schedules/:id/complete_inspection' => 'inspection_schedules#complete_inspection'
 
-  # 装置システムの点検周期を一括返還する
+  # 同一設置場所の装置システムを表示 ⇒ 点検周期を一括変更する
   get 'equipment/placed_equipment/:place_id' => 'equipment#placed_equipment', as: 'placed_equipment'
+  post 'equipment/placed_equipment/change_inspection_cycle' => 'equipment#change_inspection_cycle'
 
   resources :equipment do
     collection { post :import }  # for CSV Upload


### PR DESCRIPTION
点検周期の一括変更
1. ・設置場所一覧で(YES拠点ユーザーの場合)自拠点の管轄する場所だけを見えるように
2. ・↑の勢いで装置システムも同様にした
3. ・設置場所一覧の各行に「装置システム一覧」のリンクを作成
4. ・該当設置場所にある装置システムの一覧＆点検周期一括変更画面を新設
5. ・↑チェックボックス選択＋画面下部の数値入力フィールドに数字を入れることで選択した装置システムの点検周期をまとめて変更
6. 点検周期を変更した後のリダイレクト先を同じ画面(上の４の画面)にした。
7. 点検周期の変更を controller に直書きしてしまってるけど多分 model に移動。
