### PR TITLE
S-01019(追加)：装置システムの変更時に(DBの値によらず)点検契約をtrueにしちゃってるのを修正

### DIFF
--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -8,6 +8,7 @@ class Equipment < ActiveRecord::Base
 
   has_many :inspection_schedules
 
+  after_initialize :set_default_value, if: :new_record? # 新規作成の場合はデフォルト値を入れる
   validates :serial_number, presence: true, uniqueness: { scope: :system_model }
   validates :serial_number, format: { with: /\A[A-Z0-9-]+\z/, message: "は半角英数字とハイフンのみで記入して下さい" }
   after_save :create_inspection_schedule, if: :contracted?
@@ -22,6 +23,11 @@ class Equipment < ActiveRecord::Base
       model.attributes = row.to_hash.slice(*column_names)
       model.save!
     end
+  end
+
+  # デフォルト値の設定をする
+  def set_default_value
+    self.inspection_contract = true # 点検契約はデフォルトではONにしておく
   end
 
   def create_inspection_schedule

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -8,7 +8,6 @@ class Equipment < ActiveRecord::Base
 
   has_many :inspection_schedules
 
-  after_initialize :set_default_value, if: :new_record? # 新規作成の場合はデフォルト値を入れる
   validates :serial_number, presence: true, uniqueness: { scope: :system_model }
   validates :serial_number, format: { with: /\A[A-Z0-9-]+\z/, message: "は半角英数字とハイフンのみで記入して下さい" }
   after_save :create_inspection_schedule, if: :contracted?
@@ -23,11 +22,6 @@ class Equipment < ActiveRecord::Base
       model.attributes = row.to_hash.slice(*column_names)
       model.save!
     end
-  end
-
-  # デフォルト値の設定をする
-  def set_default_value
-    self.inspection_contract = true # 点検契約はデフォルトではONにしておく
   end
 
   def create_inspection_schedule

--- a/app/views/equipment/_form.html.erb
+++ b/app/views/equipment/_form.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="field">
     <%= f.label :inspection_contract %>
-    <%= f.check_box :inspection_contract, {:checked => @equipment.inspection_contract} %>
+    <%= f.check_box :inspection_contract %>
   </div>
   <div class="field">
     <%= f.label :inspection_cycle_month %><br>

--- a/app/views/equipment/_form.html.erb
+++ b/app/views/equipment/_form.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="field">
     <%= f.label :inspection_contract %>
-    <%= f.check_box :inspection_contract, {:checked => true} %>
+    <%= f.check_box :inspection_contract, {:checked => @equipment.inspection_contract} %>
   </div>
   <div class="field">
     <%= f.label :inspection_cycle_month %><br>

--- a/db/migrate/20150222062234_create_equipment.rb
+++ b/db/migrate/20150222062234_create_equipment.rb
@@ -3,7 +3,7 @@ class CreateEquipment < ActiveRecord::Migration
     create_table :equipment do |t|
       t.string :serial_number
       t.integer :inspection_cycle_month
-      t.boolean :inspection_contract
+      t.boolean :inspection_contract, default: true, null: false
       t.datetime :start_date
       t.references :system_model, index: true
       t.references :place, index: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20160217030958) do
   create_table "equipment", force: true do |t|
     t.string   "serial_number"
     t.integer  "inspection_cycle_month"
-    t.boolean  "inspection_contract"
+    t.boolean  "inspection_contract",    default: true, null: false
     t.datetime "start_date"
     t.integer  "system_model_id"
     t.integer  "place_id"


### PR DESCRIPTION
・点検契約の true/false を Equipment のDBのデフォルトで trueに設定するようにした。
・装置システムの新規作成画面(のview)で、点検契約のチェックボックスを問答無用で true にしてたのを equipment に設定されてる値になるよう修正（余計なコードを削除）。
