### PR TITLE
S-01017:点検の完了時：Googleマップで正しい位置が表示されるように修正

### DIFF
--- a/app/controllers/inspection_results_controller.rb
+++ b/app/controllers/inspection_results_controller.rb
@@ -11,12 +11,7 @@ class InspectionResultsController < ApplicationController
   # GET /inspection_results/1
   # GET /inspection_results/1.json
   def show
-    @marker = Gmaps4rails.build_markers(@inspection_result) do |inspection_result, marker|
-      marker.lat inspection_result.latitude
-      marker.lng inspection_result.longitude
-      marker.infowindow inspection_result.updated_at.to_s
-      marker.json(title: inspection_result.user_id.to_s)
-    end
+    @marker = @inspection_result.setup_marker
   end
 
   # GET /inspection_results/new

--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -73,6 +73,12 @@ class InspectionSchedulesController < ApplicationController
   end
 
   def close_inspection
+    @marker = Gmaps4rails.build_markers(@inspection_schedule.result) do |inspection_result, marker|
+      marker.lat inspection_result.latitude
+      marker.lng inspection_result.longitude
+      marker.infowindow inspection_result.updated_at.to_s
+      marker.json(title: inspection_result.user_id.to_s)
+    end
   end
 
   # GET /inspection_schedules/new

--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -73,12 +73,7 @@ class InspectionSchedulesController < ApplicationController
   end
 
   def close_inspection
-    @marker = Gmaps4rails.build_markers(@inspection_schedule.result) do |inspection_result, marker|
-      marker.lat inspection_result.latitude
-      marker.lng inspection_result.longitude
-      marker.infowindow inspection_result.updated_at.to_s
-      marker.json(title: inspection_result.user_id.to_s)
-    end
+    @marker = @inspection_schedule.result.setup_marker
   end
 
   # GET /inspection_schedules/new

--- a/app/models/inspection_result.rb
+++ b/app/models/inspection_result.rb
@@ -10,4 +10,14 @@ class InspectionResult < ActiveRecord::Base
 
   include Common
   after_commit :dump
+
+  def setup_marker
+    Gmaps4rails.build_markers(self) do |inspection_result, marker|
+      marker.lat inspection_result.latitude
+      marker.lng inspection_result.longitude
+      marker.infowindow inspection_result.updated_at.to_s
+      marker.json(title: inspection_result.user_id.to_s)
+    end
+  end
+
 end


### PR DESCRIPTION
点検の完了(close_inspection)をする時にGoogleMap用のマーカーが作られて無くて海上(緯度経度が０のところ？)が表示されていたのを修正。
close_inspection の処理で inspection_result　の latitude/longitude でマーカーを作るようにした。
 ⇒ マーカー作る処理を InspectionResult にまとめてしまいました。
