### PR TITLE
S-01024 YES拠点担当者でログインした場合に自分が担当している点検予定が判別できるようにした

### DIFF
--- a/app/views/inspection_schedules/index.html.erb
+++ b/app/views/inspection_schedules/index.html.erb
@@ -6,6 +6,9 @@
 <table>
   <thead>
     <tr>
+        <% if current_user.branch_employee? %>
+          <th><%= t('views.inspection_schedule.yes_branch_staff')%></th>
+        <% end %>
       <th><%= t('activerecord.attributes.inspection_schedule.target_yearmonth') %></th>
       <th><%= t('activerecord.attributes.inspection_schedule.equipment_id') %></th>
       <th><%= t('activerecord.attributes.equipment.place_id') %></th>
@@ -22,6 +25,14 @@
   <tbody>
     <% @inspection_schedules.each do |inspection_schedule| %>
       <tr>
+        <% if current_user.branch_employee? %>
+          <td>
+            <% if(inspection_schedule.user.present? &&
+               inspection_schedule.user.id == current_user.id) %>
+              <%= t('views.inspection_schedule.yes_branch_staff_mark')%>
+            <% end %>
+          </td>
+        <% end %>
         <td><%= inspection_schedule.target %></td>
         <td><%= inspection_schedule.equipment.serial_number %></td>
         <td><%= inspection_schedule.place.name %></td>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -42,7 +42,7 @@ ja:
       next_inspection_yearmonth: 次回点検年月
       my_schedules: "%{company_name}の点検予定一覧"
       schedules_by_place: "%{place_name}の点検予定一覧"
-      yes_branch_staff: 担当者
+      yes_branch_staff: 担当
       yes_branch_staff_mark: ＊
     equipment:
       index: 装置システム一覧

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -42,6 +42,8 @@ ja:
       next_inspection_yearmonth: 次回点検年月
       my_schedules: "%{company_name}の点検予定一覧"
       schedules_by_place: "%{place_name}の点検予定一覧"
+      yes_branch_staff: 担当者
+      yes_branch_staff_mark: ＊
     equipment:
       index: 装置システム一覧
       new: 装置システムの登録


### PR DESCRIPTION
ややヤッツケ感ありですが、とりあえず、ログインユーザーがYES拠点ユーザーの時に、自分が担当の点検予定について点検一覧系の表の先頭に「＊」が付いて識別できるようにしてみました。
