### PR TITLE
S-01017対応：点検予定の候補日時をdatetimepickerにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,9 @@ gem "carrierwave"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "bootstrap-sass", "~> 3.2.0"
-gem 'bootstrap-datepicker-rails'
+gem "bootstrap-datepicker-rails"
+gem "bootstrap3-datetimepicker-rails"
+gem "momentjs-rails"
 gem "font-awesome-sass"
 
 gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       railties (>= 3.0)
     bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
+    bootstrap3-datetimepicker-rails (4.17.37)
+      momentjs-rails (>= 2.8.1)
     builder (3.2.2)
     byebug (8.2.2)
     carrierwave (0.10.0)
@@ -89,6 +91,8 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.8.4)
+    momentjs-rails (2.11.0)
+      railties (>= 3.1)
     multi_json (1.11.2)
     orm_adapter (0.5.0)
     parser (2.3.0.6)
@@ -202,6 +206,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-datepicker-rails
   bootstrap-sass (~> 3.2.0)
+  bootstrap3-datetimepicker-rails
   carrierwave
   coffee-rails (~> 4.0.0)
   devise
@@ -214,6 +219,7 @@ DEPENDENCIES
   jquery-turbolinks
   jquery-ui-rails
   kaminari
+  momentjs-rails
   pg
   pry-byebug
   pry-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,9 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require bootstrap-datepicker
+//= require moment
+//= require moment/ja
+//= require bootstrap-datetimepicker
 //= require_tree .
 
 //= require underscore-min

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -9,4 +9,10 @@ $(document).ready(function(){
     language: 'ja',
     minViewMode : 'months'
   });
+
+  $(".datetime.datetimepicker").datetimepicker({
+    locale: 'ja',
+    format: 'YYYY年MM月DD日 HH時',
+    dayViewHeaderFormat: 'YYYY年 MM月'
+  });
 });

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -12,6 +12,7 @@ $(document).ready(function(){
 
   $(".datetime.datetimepicker").datetimepicker({
     locale: 'ja',
+    ignoreReadonly: true,
     format: 'YYYY年MM月DD日 HH時',
     dayViewHeaderFormat: 'YYYY年 MM月'
   });

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,6 +1,7 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import 'bootstrap-datepicker';
+@import "bootstrap-datetimepicker";
 @import "font-awesome-sprockets";
 @import "font-awesome";
 
@@ -86,4 +87,8 @@ p{
   .small {
       font-size: 95%;
   }
+}
+
+.datetimepicker-position{
+    position: relative;
 }

--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -216,9 +216,11 @@ class InspectionSchedulesController < ApplicationController
   def inspection_schedule_savable_params
     target_param = params[:inspection_schedule][:target_yearmonth]
     params[:inspection_schedule][:target_yearmonth] = Date.strptime(target_param, "%Y年%m月") if target_param.present?
-    %i(candidate_datetime1 candidate_datetime2 candidate_datetime3 confirm_datetime processingdate).each do |attribute|
+    target_param = params[:inspection_schedule][:processingdate]
+    params[:inspection_schedule][:processingdate] = Date.strptime(target_param, "%Y年%m月%d日") if target_param.present?
+    %i(candidate_datetime1 candidate_datetime2 candidate_datetime3 confirm_datetime ).each do |attribute|
       target_param = params[:inspection_schedule][attribute]
-      params[:inspection_schedule][attribute] = Date.strptime(target_param, "%Y年%m月%d日") if target_param.present?
+      params[:inspection_schedule][attribute] = DateTime.strptime(target_param, "%Y年%m月%d日 %H時")  if target_param.present?
     end
     inspection_schedule_params
   end

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -72,11 +72,15 @@ module InspectionScheduleHelper
     (text_field_for_date(f, attribute) + clear_link(attribute)).html_safe
   end
 
-  def text_field_for_date(f, attribute, month_or_date: 'date')
+  def datetime_field(f, attribute)
+    (text_field_for_date(f, attribute, month_or_date: :datetime , pick: :datetimepicker, readonly: false ) + clear_link(attribute)).html_safe
+  end
+
+  def text_field_for_date(f, attribute, month_or_date: 'date', pick: 'datepicker', readonly: true)
     f.text_field(
       attribute,
-      class: "#{month_or_date} datepicker",
-      readonly: true,
+      class: "#{month_or_date} #{pick}",
+      readonly: readonly,
       value: send("#{month_or_date}_value", @inspection_schedule.send(attribute))
     )
   end
@@ -92,4 +96,9 @@ module InspectionScheduleHelper
   def date_value(date)
     date.strftime("%Y年%m月%d日") if date.present?
   end
+
+  def datetime_value(date)
+    date.strftime("%Y年%m月%d日 %hh時") if date.present?
+  end
+
 end

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -73,14 +73,14 @@ module InspectionScheduleHelper
   end
 
   def datetime_field(f, attribute)
-    (text_field_for_date(f, attribute, month_or_date: :datetime , pick: :datetimepicker, readonly: false ) + clear_link(attribute)).html_safe
+    (text_field_for_date(f, attribute, month_or_date: :datetime , pick: :datetimepicker ) + clear_link(attribute)).html_safe
   end
 
-  def text_field_for_date(f, attribute, month_or_date: 'date', pick: 'datepicker', readonly: true)
+  def text_field_for_date(f, attribute, month_or_date: 'date', pick: 'datepicker')
     f.text_field(
       attribute,
       class: "#{month_or_date} #{pick}",
-      readonly: readonly,
+      readonly: true,
       value: send("#{month_or_date}_value", @inspection_schedule.send(attribute))
     )
   end

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -98,7 +98,7 @@ module InspectionScheduleHelper
   end
 
   def datetime_value(date)
-    date.strftime("%Y年%m月%d日 %hh時") if date.present?
+    date.strftime("%Y年%m月%d日 %HH時") if date.present?
   end
 
 end

--- a/app/views/inspection_schedules/_form.html.erb
+++ b/app/views/inspection_schedules/_form.html.erb
@@ -31,19 +31,19 @@
     <%= f.collection_select(:schedule_status_id, ScheduleStatus.all, :id, :name) %>
   </div>
 
-  <div class="field">
+  <div class="field datetimepicker-position" >
     <%= f.label :candidate_datetime1 %><br>
-    <%= date_field(f, :candidate_datetime1) %>
+    <%= datetime_field(f, :candidate_datetime1) %>
   </div>
 
-  <div class="field">
+  <div class="field datetimepicker-position">
     <%= f.label :candidate_datetime2 %><br>
-    <%= date_field(f, :candidate_datetime2) %>
+    <%= datetime_field(f, :candidate_datetime2) %>
   </div>
 
-  <div class="field">
+  <div class="field datetimepicker-position">
     <%= f.label :candidate_datetime3 %><br>
-    <%= date_field(f, :candidate_datetime3) %>
+    <%= datetime_field(f, :candidate_datetime3) %>
   </div>
 
   <div class="field">

--- a/app/views/inspection_schedules/_form.html.erb
+++ b/app/views/inspection_schedules/_form.html.erb
@@ -53,7 +53,7 @@
 
   <div class="field">
     <%= f.label :confirm_datetime %><br>
-    <%= date_field(f, :confirm_datetime) %>
+    <%= datetime_field(f, :confirm_datetime) %>
   </div>
 
   <div class="field">

--- a/app/views/inspection_schedules/_show.html.erb
+++ b/app/views/inspection_schedules/_show.html.erb
@@ -20,17 +20,17 @@
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.candidate_datetime1') %>:</strong>
-  <%= inspection_schedule.candidate_datetime1.try(:strftime, "%Y年%m月%d日") %>
+  <%= inspection_schedule.candidate_datetime1.try(:strftime, "%Y年%m月%d日　%H時") %>
 </p>
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.candidate_datetime2') %>:</strong>
-  <%= inspection_schedule.candidate_datetime2.try(:strftime, "%Y年%m月%d日") %>
+  <%= inspection_schedule.candidate_datetime2.try(:strftime, "%Y年%m月%d日　%H時") %>
 </p>
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.candidate_datetime3') %>:</strong>
-  <%= inspection_schedule.candidate_datetime3.try(:strftime, "%Y年%m月%d日") %>
+  <%= inspection_schedule.candidate_datetime3.try(:strftime, "%Y年%m月%d日　%H時") %>
 </p>
 
 <p>

--- a/app/views/inspection_schedules/answer_date.html.erb
+++ b/app/views/inspection_schedules/answer_date.html.erb
@@ -18,17 +18,17 @@
 
   <div class="field">
     <%= f.label :candidate_datetime1 %><br>
-    <%= date_field(f, :candidate_datetime1) %>
+    <%= datetime_field(f, :candidate_datetime1) %>
   </div>
 
   <div class="field">
     <%= f.label :candidate_datetime2 %><br>
-    <%= date_field(f, :candidate_datetime2) %>
+    <%= datetime_field(f, :candidate_datetime2) %>
   </div>
 
   <div class="field">
     <%= f.label :candidate_datetime3 %><br>
-    <%= date_field(f, :candidate_datetime3) %>
+    <%= datetime_field(f, :candidate_datetime3) %>
   </div>
 
   <div class="field">

--- a/app/views/inspection_schedules/confirm_date.html.erb
+++ b/app/views/inspection_schedules/confirm_date.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= f.label :confirm_datetime %><br>
-    <%= date_field(f, :confirm_datetime) %>
+    <%= datetime_field(f, :confirm_datetime) %>
   </div>
 
   <div class="field">


### PR DESCRIPTION
datetimepickerを点検予定の候補日時１～３で、使えるようにしたバージョンです。
gemは「bootstrap3-datetimepicker-rails」を利用しています。

WIPなのは、現在、問題点が３つ残っている状態なためです。 :crying_cat_face: 

 **1. text_fieldに書き込める**
　text_feildがreadonlyのままだと、detetimepickerを呼び出せないため、readonlyを無効にしています。
　
 **2. 登録した時刻と登録後の表示画面で、時刻がずれている**
　datetimepickerで表示した時刻を、どうも変換なしのまま処理してるっぽい感じ…
　（登録時刻と表示時刻が9hずれているので）
　
 **3. 登録した時刻をdatetimepickerで、表示できない**
 　…多分単純なフォーマットミスな気がする… :sweat_drops: 
