### PR TITLE
TK-01067, TK-01068, TK01069, TK-01066 (表示関係残件詰め合わせ)

### DIFF
--- a/app/assets/javascripts/equipment.js.coffee
+++ b/app/assets/javascripts/equipment.js.coffee
@@ -12,4 +12,4 @@ $ ->
   $.ajax
     url: '/equipment/change_inspection_contract'
     type: 'GET'
-    data: checked: $('input#equipment_inspection_contract').prop('checked')
+    data: checked: $('input#equipment_inspection_contract').prop('checked'), system_model_id: $('select#equipment_system_model_id').val()

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -104,6 +104,7 @@ class EquipmentController < ApplicationController
 
   def change_inspection_contract
     @inspection_contract = (params[:checked] == 'true')
+    @system_model = SystemModel.find(params[:system_model_id])
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def admin?
+    current_user.admin?
+  end
 end

--- a/app/helpers/equipment_helper.rb
+++ b/app/helpers/equipment_helper.rb
@@ -26,8 +26,8 @@ module EquipmentHelper
     @equipment.new_record? ? current_user.branch.id : @equipment.branch_id
   end
 
-  def inspection_contract_string
-    if @equipment.inspection_contract then
+  def inspection_contract_string(equipment)
+    if equipment.inspection_contract then
       t('views.equipment.inspection_contract_true')
     else
       t('views.equipment.inspection_contract_false')

--- a/app/helpers/equipment_helper.rb
+++ b/app/helpers/equipment_helper.rb
@@ -26,11 +26,7 @@ module EquipmentHelper
     @equipment.new_record? ? current_user.branch.id : @equipment.branch_id
   end
 
-  def inspection_contract_string(equipment)
-    if equipment.inspection_contract then
-      t('views.equipment.inspection_contract_true')
-    else
-      t('views.equipment.inspection_contract_false')
-    end
+  def inspection_contract_string(equipment = nil)
+      t("views.equipment.inspection_contract_#{(equipment || @equipment).inspection_contract ? 'true' : 'false'}")
   end
 end

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -194,11 +194,6 @@ module InspectionScheduleHelper
     end
   end
 
-  # 削除
-  def show_delete?
-    permit_company?(%i(head))
-  end
-
   def permit_action?(actions)
     actions.include?(params[:action].to_sym)
   end

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -190,7 +190,7 @@ module InspectionScheduleHelper
 
   # 削除
   def show_delete?
-    current_user.head_employee?
+    permit_company?(%i(head))
   end
 
   def permit_action?(actions)

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -101,7 +101,7 @@ module InspectionScheduleHelper
     date.strftime("%Y年%m月%d日 %HH時") if date.present?
   end
 
-  # 年月
+  # 予定年月
   def show_target_yearmonth?
     permit_action?(%i(index need_request requested_soon date_answered)) &&
     permit_company?(%i(head branch service))
@@ -186,6 +186,11 @@ module InspectionScheduleHelper
       when :done then false
       else false
     end
+  end
+
+  # 削除
+  def show_delete?
+    current_user.head_employee?
   end
 
   def permit_action?(actions)

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -101,6 +101,12 @@ module InspectionScheduleHelper
     date.strftime("%Y年%m月%d日 %HH時") if date.present?
   end
 
+  # 担当
+  def show_yes_branch_staff?
+    permit_action?(%i(index requested_soon date_answered target done)) &&
+    permit_company?(%i(branch))
+  end
+
   # 予定年月
   def show_target_yearmonth?
     permit_action?(%i(index need_request requested_soon date_answered)) &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ActiveRecord::Base
     company.try(:type) == 'Service'
   end
 
+  def admin?
+    head_employee?
+  end
+
   def jurisdiction_services
     branch_employee? ? company.services : []
   end

--- a/app/views/equipment/change_inspection_contract.js.erb
+++ b/app/views/equipment/change_inspection_contract.js.erb
@@ -1,1 +1,2 @@
 $('input#equipment_inspection_cycle_month').prop('disabled', <%= !@inspection_contract %>);
+$('input#equipment_inspection_cycle_month').val('<%= @system_model.inspection_cycle_month if @inspection_contract %>');

--- a/app/views/equipment/change_system_model.js.erb
+++ b/app/views/equipment/change_system_model.js.erb
@@ -1,1 +1,1 @@
-$('input#equipment_inspection_cycle_month').val('<%= @system_model.inspection_cycle_month %>')
+$('input#equipment_inspection_cycle_month').val('<%= @system_model.inspection_cycle_month %>');

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -28,7 +28,7 @@
         <td><%= equipment.service.name %></td>
         <td><%= link_to t('views.link_to.show'), equipment %></td>
         <td><%= link_to t('views.link_to.edit'), edit_equipment_path(equipment) %></td>
-        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } if show_delete? %></td>
+        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } if admin? %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -8,19 +8,23 @@
       <th></th>
       <th><%= t('activerecord.attributes.equipment.system_model_id') %></th>
       <th><%= t('activerecord.attributes.equipment.serial_number') %></th>
+      <th><%= t('activerecord.attributes.equipment.start_date') %></th>
+      <th><%= t('activerecord.attributes.equipment.inspection_contract') %></th>
       <th><%= t('activerecord.attributes.equipment.inspection_cycle_month') %></th>
       <th><%= t('activerecord.attributes.equipment.service_id') %></th>
-      <th colspan="5"></th>
+      <th colspan="3"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @equipment.each do |equipment| %>
       <tr>
-        <td><%= check_box 'check', equipment.id, :id => "equipment_#{equipment.id}" %></td>
+        <td><%= check_box 'check', equipment.id, :id => "equipment_#{equipment.id}", :disabled => !equipment.inspection_contract %></td>
         <td><%= equipment.system_model.name %></td>
         <td><%= equipment.serial_number %></td>
-        <td><%= equipment.inspection_cycle_month %></td>
+        <td><%= l(equipment.start_date, format: :start_date) %></td>
+        <td><%= inspection_contract_string(equipment) %></td>
+        <td><%= equipment.inspection_cycle_month if equipment.inspection_contract %></td>
         <td><%= equipment.service.name %></td>
         <td><%= link_to t('views.link_to.show'), equipment %></td>
         <td><%= link_to t('views.link_to.edit'), edit_equipment_path(equipment) %></td>

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -28,7 +28,7 @@
         <td><%= equipment.service.name %></td>
         <td><%= link_to t('views.link_to.show'), equipment %></td>
         <td><%= link_to t('views.link_to.edit'), edit_equipment_path(equipment) %></td>
-        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } if current_user.head_employee? %></td>
+        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } if show_delete? %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/equipment/placed_equipment.html.erb
+++ b/app/views/equipment/placed_equipment.html.erb
@@ -28,7 +28,7 @@
         <td><%= equipment.service.name %></td>
         <td><%= link_to t('views.link_to.show'), equipment %></td>
         <td><%= link_to t('views.link_to.edit'), edit_equipment_path(equipment) %></td>
-        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to t('views.link_to.destroy'), equipment, method: :delete, data: { confirm: 'Are you sure?' } if current_user.head_employee? %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -15,7 +15,7 @@
 
 <p>
   <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
-  <%= inspection_contract_string(@equipment) %>
+  <%= inspection_contract_string %>
 </p>
 
 <p>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -15,7 +15,7 @@
 
 <p>
   <strong><%= t('activerecord.attributes.equipment.inspection_contract') %>:</strong>
-  <%= inspection_contract_string %>
+  <%= inspection_contract_string(@equipment) %>
 </p>
 
 <p>

--- a/app/views/inspection_schedules/_show.html.erb
+++ b/app/views/inspection_schedules/_show.html.erb
@@ -1,6 +1,6 @@
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.target_yearmonth') %>:</strong>
-  <%= inspection_schedule.target_yearmonth.strftime("%Y年%m月") %>
+  <%= l(inspection_schedule.target_yearmonth, format: :target_yearmonth) %>
 </p>
 
 <p>
@@ -20,17 +20,17 @@
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.candidate_datetime1') %>:</strong>
-  <%= inspection_schedule.candidate_datetime1.try(:strftime, "%Y年%m月%d日　%H時") %>
+  <%= l(inspection_schedule.candidate_datetime1, format: :candidate_long) %>
 </p>
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.candidate_datetime2') %>:</strong>
-  <%= inspection_schedule.candidate_datetime2.try(:strftime, "%Y年%m月%d日　%H時") %>
+  <%= l(inspection_schedule.candidate_datetime2, format: :candidate_long) %>
 </p>
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.candidate_datetime3') %>:</strong>
-  <%= inspection_schedule.candidate_datetime3.try(:strftime, "%Y年%m月%d日　%H時") %>
+  <%= l(inspection_schedule.candidate_datetime3, format: :candidate_long) %>
 </p>
 
 <p>
@@ -40,7 +40,7 @@
 
 <p>
   <strong><%= t('activerecord.attributes.inspection_schedule.confirm_datetime') %>:</strong>
-  <%= inspection_schedule.confirm_datetime.try(:strftime, "%Y年%m月%d日") %>
+  <%= l(inspection_schedule.confirm_datetime, format: :confirm_long) %>
 </p>
 
 <p>

--- a/app/views/inspection_schedules/index.html.erb
+++ b/app/views/inspection_schedules/index.html.erb
@@ -6,7 +6,7 @@
 <table>
   <thead>
     <tr>
-      <%= content_tag :th, t('views.inspection_schedule.yes_branch_staff') %>
+      <%= content_tag :th, t('views.inspection_schedule.yes_branch_staff') if show_yes_branch_staff? %>
       <%= content_tag :th, t('activerecord.attributes.inspection_schedule.target_yearmonth') if show_target_yearmonth? %>
       <%= content_tag :th, t('activerecord.attributes.inspection_schedule.confirm_datetime') if show_confirm_datetime? %>
       <%= content_tag :th, t('activerecord.attributes.equipment.system_model_id') if show_system_model? %>
@@ -30,12 +30,13 @@
   <tbody>
     <% @inspection_schedules.each do |inspection_schedule| %>
       <tr>
-        <td>
-          <% if(inspection_schedule.user.present? &&
-             inspection_schedule.user.id == current_user.id) %>
+        <% if( show_yes_branch_staff? &&
+               inspection_schedule.user.present? &&
+               inspection_schedule.user.id == current_user.id) %>
+          <td>
             <%= t('views.inspection_schedule.yes_branch_staff_mark')%>
-          <% end %>
-        </td>
+          </td>
+        <% end %>
         <%= content_tag :td, l(inspection_schedule.target_yearmonth, format: :target_yearmonth) if show_target_yearmonth? %>
         <%= content_tag :td, l(inspection_schedule.confirm_datetime, format: :confirm) if show_confirm_datetime? %>
         <%= content_tag :td, inspection_schedule.equipment.system_model.name if show_system_model? %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -194,6 +194,8 @@ ja:
       short: ! '%y/%m/%d %H:%M'
       target_yearmonth: '%Y年%m月'
       candidate: '%m月%d日 %H時'
+      candidate_long: '%Y年%m月%d日 %H時'
       confirm: '%m月%d日 %H時'
+      confirm_long: '%Y年%m月%d日 %H時'
       start_date: '%Y年%m月%d日'
     pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -195,4 +195,5 @@ ja:
       target_yearmonth: '%Y年%m月'
       candidate: '%m月%d日 %H時'
       confirm: '%m月%d日 %H時'
+      start_date: '%Y年%m月%d日'
     pm: 午後


### PR DESCRIPTION
TK-01067:同一設置場所の所有機の点検周期をまとめて変える時の点検契約無の考慮
１．同一設置場所の所有機一覧の表示項目を調整
　　※試運転日、点検契約(有無)を表示するようにした
２．点検周期は点検契約=有の時だけ表示するようにするようにした
３．変更対象を選ぶチェックボックスは点検契約＝有の時だけチェック可(無の時はチェック不可)とした
４．点検契約の有無文字列のためにヘルパーの inspection_contract_string を使いたかった…のだけど
　　見たら @equipment を使ってたので引数を渡すように修正＆使ってる show も併せて修正
５．[削除」のリンクが出るのはYES本社ユーザーの時だけにする

TK-01068:点検予定の詳細で「確定日時」に時が出てない
１．確定日時(年月日時まで)表示用のフォーマットを作って使うようにした
２．あわせて、i18n的な書き方になってなかったところを一緒に修正

TK-01069:サービス会社ユーザーがログインした場合は点検予定一覧系の「担当」はナシで
１．InspectionScheduleHelper に表示するかどうか判断する系のを追加
２．↑を使ってサービス会社の時だけ「担当」が出るようにした
３．ついでに「要点検依頼一覧」の時は(担当が決まってないものの一覧なので)「担当」列の表示はナシにした

ask TK-01066:装置システムので点検契約を「無」→「有」に変更した場合に点検周期が自動セットされない
１．所有機の更新画面で点検契約有無を変更した時の処理を修正
　　a. 無⇒有の時：型式の点検周期が[点検周期]入力エリアにセットされる
　　b. 有⇒無の時：[点検周期]エリアをクリア　※たぶんこれでいいはず……
