### PR TITLE
(Sprint3-Review版既知の不具合)TK-01072:次回点検予定を作る時の点検実施会社は所有機のデフォルトにする

### DIFF
--- a/app/models/inspection_schedule.rb
+++ b/app/models/inspection_schedule.rb
@@ -53,7 +53,7 @@ class InspectionSchedule < ActiveRecord::Base
     InspectionSchedule.create(
       target_yearmonth: yearmonth,
       equipment: equipment,
-      service: service,
+      service: equipment.service,
       schedule_status_id: ScheduleStatus.of_need_request
     )
   end


### PR DESCRIPTION
次回点検予定を作る時、点検実施会社として今回の点検予定を担当したサービス会社を設定していたが、そうではなく、装置システムに設定されている、デフォルトの点検実施会社を設定すべき……という事でそのように修正。
