### PR TITLE
残件(微調整)諸々

### DIFF
--- a/app/controllers/inspection_schedules_controller.rb
+++ b/app/controllers/inspection_schedules_controller.rb
@@ -58,7 +58,8 @@ class InspectionSchedulesController < ApplicationController
 
   # GET /inspection_schedules/1/do_inspection
   def do_inspection
-    if @inspection_schedule.can_inspection?(current_user) # 点検開始して良い状態か？
+    if @inspection_schedule.can_inspection?(current_user) or # 点検開始して良い状態か？
+       @inspection_schedule.doing?(current_user) # 点検中か？
       if @inspection_schedule.result.nil? # 初回か？ → 初回なら点検実績を新規作成
         @inspection_result = InspectionResult.new(inspection_schedule: @inspection_schedule)
         @inspection_result.user = current_user

--- a/app/helpers/equipment_helper.rb
+++ b/app/helpers/equipment_helper.rb
@@ -51,6 +51,13 @@ module EquipmentHelper
     )
   end
 
+  def show_serial_number_link(equipment)
+    show_attribute(
+      t('activerecord.attributes.equipment.serial_number'),
+      ( link_to equipment.serial_number, equipment_path(equipment) )
+    )
+  end
+
   def show_place(equipment = nil)
     show_attribute(
       t('activerecord.attributes.equipment.place_id'),

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -347,4 +347,9 @@ module InspectionScheduleHelper
       return ''
     end
   end
+
+  def index_all?
+    if params[:action].to_sym == :index then true else false end
+  end
+
 end

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -69,19 +69,19 @@ module InspectionScheduleHelper
 
     # 候補日時回答可能時　※サービス会社ユーザーは変更不可
     elsif inspection_schedule.can_answer_date?(current_user) && !current_user.service_employee?
-      fa_refresh_link_to t('views.inspection_schedule.inspection_request'), inspection_request_path(inspection_schedule)
+      fa_refresh_link_to t('views.inspection_schedule.correct_inspection_request'), inspection_request_path(inspection_schedule)
 
     # 日程確定可能時
     elsif inspection_schedule.can_confirm_date?(current_user)
-      fa_refresh_link_to t('views.inspection_schedule.answer_date'), answer_date_path(inspection_schedule)
+      fa_refresh_link_to t('views.inspection_schedule.correct_answer_date'), answer_date_path(inspection_schedule)
 
     # 点検実施可能時(日程確定済の場合)
     elsif inspection_schedule.schedule_status_id == ScheduleStatus.of_dates_confirmed && !current_user.service_employee?
-      fa_refresh_link_to t('views.inspection_schedule.confirm_date'), confirm_date_path(inspection_schedule)
+      fa_refresh_link_to t('views.inspection_schedule.correct_confirm_date'), confirm_date_path(inspection_schedule)
 
     # サイン可能時
     elsif inspection_schedule.can_approval?(current_user)
-      fa_refresh_link_to t('views.inspection_schedule.do_inspecrion'), do_inspection_path(inspection_schedule)
+      fa_refresh_link_to t('views.inspection_schedule.correct_inspecrion_report'), do_inspection_path(inspection_schedule)
 
     # 承認可能時　※変更不可
     elsif inspection_schedule.can_close_inspection?(current_user)

--- a/app/views/inspection_schedules/_show.html.erb
+++ b/app/views/inspection_schedules/_show.html.erb
@@ -1,5 +1,5 @@
 <%= show_system_model(@inspection_schedule.equipment) %>
-<%= show_serial_number(@inspection_schedule.equipment) %>
+<%= show_serial_number_link(@inspection_schedule.equipment) %>
 <%= show_place(@inspection_schedule.equipment) %>
 
 <%= show_target_yearmonth %>

--- a/app/views/inspection_schedules/index.html.erb
+++ b/app/views/inspection_schedules/index.html.erb
@@ -23,7 +23,7 @@
       <%= content_tag :th, t('activerecord.attributes.inspection_schedule.schedule_status_id') if show_schedule_status? %>
       <%= content_tag :th if show_action? %>
       <th></th>
-      <th></th>
+      <% if index_all? %><th></th><% end %>
       <%= content_tag :th if show_edit? %>
     </tr>
   </thead>
@@ -48,7 +48,7 @@
         <%= content_tag :td, inspection_schedule.status.name if show_schedule_status? %>
         <%= content_tag :td, action_link(inspection_schedule) if show_action? %>
         <%= content_tag :td, fa_newspaper_link_to( t('views.link_to.show'), inspection_schedule_path(inspection_schedule)) %>
-        <%= content_tag :td, correct_link(inspection_schedule) %>
+        <%= content_tag :td, correct_link(inspection_schedule) if index_all?%>
         <%= content_tag :td, fa_refresh_link_to( t('views.link_to.edit'), edit_inspection_schedule_path(inspection_schedule) ) if show_edit? %>
       </tr>
     <% end %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -35,9 +35,13 @@ ja:
       show: 点検予定の確認
       correct_targetyearmonth: 予定年月訂正
       inspection_request: 点検依頼
+      correct_inspection_request: 点検依頼訂正
       answer_date: 候補日時回答
+      correct_answer_date: 候補日時訂正
       confirm_date: 出張依頼
+      correct_confirm_date: 出張依頼訂正
       do_inspecrion: 点検報告作成
+      correct_inspecrion_report: 点検報告訂正
       done_inspection: サイン
       close_inspecrion: 承認
       next_inspection_yearmonth: 次回点検年月


### PR DESCRIPTION
１．点検予定の詳細で「所有機」の「シリアルNo.」からその所有機の詳細ページに行ける(そして整備来歴が見られる)筈だったのを、 #96 の時(各項目を表示する部分をヘルパーに移動させた時)に無くしちゃってたのでやり直し。

２．訂正系(点検依頼の訂正とか候補日時の訂正とか)のリンク名がステータスを進める系のリンク名と同じだったのは紛らわしいので「～訂正」という名前にした。　※views.ja.yml に文言を増やしてます。

３．点検報告の訂正ができない(いちど登録すると後から治せない)状態なのを、ステータスが点検中であれば訂正できるようにした。
　※ do_inspection の条件が「点検開始できる」だけだったのを「点検かいしできる、もしくは、点検中」にしました。これで、うっかり間違えて途中で登録してもサインをもらうまでは内容を修正できるようになりました。（コード見ると、そうするつもりでやかけて…でもやりきれてない感じだった… :sweat: ）

４．訂正系のリンクが「日常業務」に出るのは何となく違和感(点検報告の訂正はアリかもですが…)だったので、「点検予定一覧(すべて)」の方だけに出るようにした。
