### PR TITLE
Sprint4 スプリントレビュー時の不具合(1個)＆要望(2個)つめあわせ

### DIFF
--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -339,6 +339,14 @@ module InspectionScheduleHelper
     )
   end
 
+  # 点検依頼者
+  def show_yes_branch_staff_orderd
+    show_attribute(
+      t('views.inspection_schedule.yes_branch_staff_orderd'),
+      (@inspection_schedule.user.name if @inspection_schedule.user.present?)
+    )
+  end
+
   # 一覧上の[担当]マーク
   def yes_branch_staff_mark(inspection_schedule)
     if inspection_schedule.user.present? && inspection_schedule.user.id == current_user.id

--- a/app/helpers/inspection_schedule_helper.rb
+++ b/app/helpers/inspection_schedule_helper.rb
@@ -148,7 +148,7 @@ module InspectionScheduleHelper
 
   # 担当
   def show_yes_branch_staff?
-    permit_action?(%i(index requested_soon date_answered target done)) &&
+    permit_action?(%i(index requested_soon date_answered target done show)) &&
       permit_company?(%i(branch))
   end
 

--- a/app/views/inspection_schedules/_index_by_place.html.erb
+++ b/app/views/inspection_schedules/_index_by_place.html.erb
@@ -2,7 +2,7 @@
 <table>
   <thead>
     <tr>
-      <%= content_tag :th, t('views.inspection_schedule.yes_branch_staff') if permit_company?(%i(branch)) %>
+      <%= content_tag :th, t('views.inspection_schedule.yes_branch_staff') if show_yes_branch_staff? %>
       <%= content_tag :th, t('activerecord.attributes.inspection_schedule.target_yearmonth') %>
       <%= content_tag :th, t('activerecord.attributes.equipment.system_model_id') %>
       <%= content_tag :th, t('activerecord.attributes.equipment.serial_number') %>
@@ -15,9 +15,7 @@
   <tbody>
     <% @same_place_inspection_schedules.each do |inspection_schedule| %>
       <tr>
-        <% if show_yes_branch_staff? && (inspection_schedule.user.try(:id) == current_user.id) %>
-          <td><%= t('views.inspection_schedule.yes_branch_staff_mark')%></td>
-        <% end %>
+        <%= content_tag :td, yes_branch_staff_mark(inspection_schedule) if show_yes_branch_staff? %>
         <%= content_tag :td, l(inspection_schedule.target_yearmonth, format: :target_yearmonth) %>
         <%= content_tag :td, inspection_schedule.equipment.system_model.name %>
         <%= content_tag :td, inspection_schedule.equipment.serial_number %>

--- a/app/views/inspection_schedules/answer_date.html.erb
+++ b/app/views/inspection_schedules/answer_date.html.erb
@@ -16,6 +16,8 @@
 
   <%= f.hidden_field :schedule_status_id, value: ScheduleStatus.of_date_answered %>
 
+  <%= show_yes_branch_staff_orderd %>
+
   <%= show_system_model(@inspection_schedule.equipment) %>
   <%= show_serial_number(@inspection_schedule.equipment) %>
   <%= show_place(@inspection_schedule.equipment) %>

--- a/app/views/inspection_schedules/do_inspection.html.erb
+++ b/app/views/inspection_schedules/do_inspection.html.erb
@@ -16,6 +16,7 @@
 
 <div class="row">
   <div class="col-md-3 col-sm-3 col-xs-4">
+    <%= show_yes_branch_staff_orderd %>
     <%= show_system_model(@inspection_schedule.equipment) %>
     <%= show_serial_number(@inspection_schedule.equipment) %>
     <%= show_place(@inspection_schedule.equipment) %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -48,6 +48,7 @@ ja:
       schedules_by_place: 同一設置場所の点検予定一覧
       yes_branch_staff: 担当
       yes_branch_staff_mark: ＊
+      yes_branch_staff_orderd: 発注窓口 
     equipment:
       index: 所有機一覧
       new: 所有機の登録

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -45,7 +45,7 @@ ja:
       done_inspection: サイン
       close_inspecrion: 承認
       next_inspection_yearmonth: 次回点検年月
-      schedules_by_place: "併設機の点検予定一覧"
+      schedules_by_place: 同一設置場所の点検予定一覧
       yes_branch_staff: 担当
       yes_branch_staff_mark: ＊
     equipment:


### PR DESCRIPTION
１．(不具合)点検予定の詳細画面下部に表示する、同一設置場所の他の点検予定の表で「担当」のマークが出ていない。
２．(要望)↑の表のタイトルを[同一設置場所の点検予定一覧]に変更してほしい。
３．(要望)[候補日時回答]と[点検報告作成]画面で、項目の一番上に、点検予定-点検依頼者を表示してほしい。項目名は[発注窓口]にて。
