### PR TITLE
機器の点検周期を変更しようとする場合にエラーとなるのを修正

### DIFF
--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -41,7 +41,7 @@ class Equipment < ActiveRecord::Base
   def self.bulk_change_inspection_cycle(target_list, new_inspection_cycle_month)
     target_list.each do |key, val|
       next unless val == '1'
-      equipment = Equipment.find_by(key)
+      equipment = Equipment.find(key)
       equipment.inspection_cycle_month = new_inspection_cycle_month
       equipment.save
     end


### PR DESCRIPTION
所有機の点検周期を一括で変える(Sprint4レビューシナリオ:S04-03)で、単一変更・複数変更共に
PostgreSQLだとエラーとなっていたので、find_by→ findに修正しました。
※SQLiteだとエラーとはならないけど、指定した行の点検周期が変更できない状態でした…
